### PR TITLE
Fix Class Library Index p tags

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -35,6 +35,10 @@ table
 	word-break: break-all;
 }
 
+table p {
+  word-break: normal;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/wiki/class-library-api/index.md
+++ b/wiki/class-library-api/index.md
@@ -8,35 +8,35 @@ The class library reference contains links between the native API and the manage
 # Graphics 3D APIs
 
 Managed | Native
------ | --------------------------------
-[`SharpDX.Direct3D9`](direct3d9) | [`Direct3D9`](https://msdn.microsoft.com/en-us/library/windows/desktop/bb219837.aspx) <p>Microsoft Direct3D 9 graphics API (deprecated)</p>
-[`SharpDX.Direct3D11`](direct3d11) | [`Direct3D11`](https://msdn.microsoft.com/en-us/library/windows/desktop/ff476080.aspx) <p>Microsoft Direct3D 11 graphics to create 3-D graphics for games and scientific and desktop applications.</p>
-[`SharpDX.Direct3D12`](direct3d12) | [`Direct3D12`](https://msdn.microsoft.com/en-us/library/windows/desktop/dn903821.aspx) <p>The Direct3D 12 programming guide contains information about how to use the Direct3D 12 programmable pipeline to create a customized graphics engine.</p>
-[`SharpDX.D3DCompiler`](d3dcompiler) | [`D3DCompiler`](https://msdn.microsoft.com/en-us/library/windows/desktop/dd607340.aspx) <p>The Direct3D shader compiler API.</p>
-[`SharpDX.DXGI`](dxgi) | [`DXGI`](https://msdn.microsoft.com/en-us/library/windows/desktop/hh404534.aspx) <p>Microsoft DirectX Graphics Infrastructure (DXGI) handles enumerating graphics adapters, enumerating display modes, selecting buffer formats, sharing resources between processes (such as, between applications and the Desktop Window Manager (DWM)), and presenting rendered frames to a window or monitor for display.</p>
+------- | --------------------------------
+[`SharpDX.Direct3D9`](direct3d9) | [`Direct3D9`](https://msdn.microsoft.com/en-us/library/windows/desktop/bb219837.aspx) {::nomarkdown}<p>Microsoft Direct3D 9 graphics API (deprecated)</p>{:/}
+[`SharpDX.Direct3D11`](direct3d11) | [`Direct3D11`](https://msdn.microsoft.com/en-us/library/windows/desktop/ff476080.aspx) {::nomarkdown}<p>Microsoft Direct3D 11 graphics to create 3-D graphics for games and scientific and desktop applications.</p>{:/}
+[`SharpDX.Direct3D12`](direct3d12) | [`Direct3D12`](https://msdn.microsoft.com/en-us/library/windows/desktop/dn903821.aspx) {::nomarkdown}<p>The Direct3D 12 programming guide contains information about how to use the Direct3D 12 programmable pipeline to create a customized graphics engine.</p>{:/}
+[`SharpDX.D3DCompiler`](d3dcompiler) | [`D3DCompiler`](https://msdn.microsoft.com/en-us/library/windows/desktop/dd607340.aspx) {::nomarkdown}<p>The Direct3D shader compiler API.</p>{:/}
+[`SharpDX.DXGI`](dxgi) | [`DXGI`](https://msdn.microsoft.com/en-us/library/windows/desktop/hh404534.aspx) {::nomarkdown}<p>Microsoft DirectX Graphics Infrastructure (DXGI) handles enumerating graphics adapters, enumerating display modes, selecting buffer formats, sharing resources between processes (such as, between applications and the Desktop Window Manager (DWM)), and presenting rendered frames to a window or monitor for display.</p>{:/}
 
 # Graphics 2D APIs
 
 Managed | Native
------ | --------------------------------
-[`SharpDX.Direct2D1`](direct2d1) | [`Direct2D1`](https://msdn.microsoft.com/en-us/library/windows/desktop/dd370990.aspx) <p>Direct2D is a hardware-accelerated, immediate-mode, 2-D graphics API that provides high performance and high-quality rendering for 2-D geometry, bitmaps, and text.</p>
-[`SharpDX.DirectWrite`](directwrite) | [`DirectWrite`](https://msdn.microsoft.com/en-us/library/windows/desktop/dd368038.aspx) <p>Today's applications must support high-quality text rendering, resolution-independent outline fonts, and full Unicode text and layout support.</p>
-[`SharpDX.WIC`](wic) | [`WIC`](https://msdn.microsoft.com/en-us/library/windows/desktop/ee719902.aspx) <p>The Windows Imaging Component (WIC) is an extensible platform that provides low-level API for digital images.</p>
-[`SharpDX.DirectComposition`](directcomposition) | [`DirectComposition`](https://msdn.microsoft.com/en-us/library/windows/desktop/hh437371.aspx) <p>Microsoft DirectComposition is a Windows component that enables high-performance bitmap composition with transforms, effects, and animation</p>
+------- | --------------------------------
+[`SharpDX.Direct2D1`](direct2d1) | [`Direct2D1`](https://msdn.microsoft.com/en-us/library/windows/desktop/dd370990.aspx) {::nomarkdown}<p>Direct2D is a hardware-accelerated, immediate-mode, 2-D graphics API that provides high performance and high-quality rendering for 2-D geometry, bitmaps, and text.</p>{:/}
+[`SharpDX.DirectWrite`](directwrite) | [`DirectWrite`](https://msdn.microsoft.com/en-us/library/windows/desktop/dd368038.aspx) {::nomarkdown}<p>Today's applications must support high-quality text rendering, resolution-independent outline fonts, and full Unicode text and layout support.</p>{:/}
+[`SharpDX.WIC`](wic) | [`WIC`](https://msdn.microsoft.com/en-us/library/windows/desktop/ee719902.aspx) {::nomarkdown}<p>The Windows Imaging Component (WIC) is an extensible platform that provides low-level API for digital images.</p>{:/}
+[`SharpDX.DirectComposition`](directcomposition) | [`DirectComposition`](https://msdn.microsoft.com/en-us/library/windows/desktop/hh437371.aspx) {::nomarkdown}<p>Microsoft DirectComposition is a Windows component that enables high-performance bitmap composition with transforms, effects, and animation</p>{:/}
 
 # Input APIs
 
 Managed | Native
------ | --------------------------------
-[`SharpDX.DirectInput`](directinput) | [`DirectInput`](https://msdn.microsoft.com/en-us/library/windows/desktop/ee416842.aspx) <p>The DirectInput API is used to process data from a joystick, or other game controller.</p>
-[`SharpDX.XInput`](xinput) | [`XInput`](https://msdn.microsoft.com/en-us/library/windows/desktop/hh405053.aspx) <p>XInput Game Controller API enables applications to receive input from the Xbox 360 Controller for Windows.</p>
-[`SharpDX.RawInput`](rawinput) | [`RawInput`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms645536.aspx) <p>RawInput API</p>
+------- | --------------------------------
+[`SharpDX.DirectInput`](directinput) | [`DirectInput`](https://msdn.microsoft.com/en-us/library/windows/desktop/ee416842.aspx) {::nomarkdown}<p>The DirectInput API is used to process data from a joystick, or other game controller.</p>{:/}
+[`SharpDX.XInput`](xinput) | [`XInput`](https://msdn.microsoft.com/en-us/library/windows/desktop/hh405053.aspx) {::nomarkdown}<p>XInput Game Controller API enables applications to receive input from the Xbox 360 Controller for Windows.</p>{:/}
+[`SharpDX.RawInput`](rawinput) | [`RawInput`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms645536.aspx) {::nomarkdown}<p>RawInput API</p>{:/}
 
 # Audio and Media APIs
 
 Managed | Native
------ | --------------------------------
-[`SharpDX.XAudio2`](xaudio2) | [`XAudio2`](https://msdn.microsoft.com/en-us/library/windows/desktop/hh405049.aspx) <p>XAudio2 is a low-level audio API that provides signal processing and mixing foundation for developing high performance audio engines for games.</p>
-[`SharpDX.X3DAudio`](x3daudio) | [`X3DAudio`](https://msdn.microsoft.com/en-us/library/windows/desktop/ee415714.aspx) <p>X3DAudio is an API used in conjunction with XAudio2 to create the illusion of a sound coming from a point in 3D space.</p>
-[`SharpDX.DirectSound`](directsound) | [`DirectSound`](https://msdn.microsoft.com/en-us/library/windows/desktop/ee416960.aspx) <p>DirectSound API (deprecated)</p>
-[`SharpDX.MediaFoundation`](mediafoundation) | [`MediaFoundation`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms694197.aspx) <p>Microsoft Media Foundation enables the development of applications and components for using digital media on Windows Vista and later.</p>
+------- | --------------------------------
+[`SharpDX.XAudio2`](xaudio2) | [`XAudio2`](https://msdn.microsoft.com/en-us/library/windows/desktop/hh405049.aspx) {::nomarkdown}<p>XAudio2 is a low-level audio API that provides signal processing and mixing foundation for developing high performance audio engines for games.</p>{:/}
+[`SharpDX.X3DAudio`](x3daudio) | [`X3DAudio`](https://msdn.microsoft.com/en-us/library/windows/desktop/ee415714.aspx) {::nomarkdown}<p>X3DAudio is an API used in conjunction with XAudio2 to create the illusion of a sound coming from a point in 3D space.</p>{:/}
+[`SharpDX.DirectSound`](directsound) | [`DirectSound`](https://msdn.microsoft.com/en-us/library/windows/desktop/ee416960.aspx) {::nomarkdown}<p>DirectSound API (deprecated)</p>{:/}
+[`SharpDX.MediaFoundation`](mediafoundation) | [`MediaFoundation`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms694197.aspx) {::nomarkdown}<p>Microsoft Media Foundation enables the development of applications and components for using digital media on Windows Vista and later.</p>{:/}


### PR DESCRIPTION
This is the best solution I could find for the new kramdown parser.

Preview: https://mattico.github.io/wiki/class-library-api/